### PR TITLE
Fix corfu error when there is no :company-kind property

### DIFF
--- a/nerd-icons-corfu.el
+++ b/nerd-icons-corfu.el
@@ -118,8 +118,8 @@ It receives METADATA, ignores it, and outputs a function that takes a candidate
 and returns the icon."
   (when-let ((kindfunc (plist-get completion-extra-properties :company-kind)))
     (lambda (cand)
-      (when-let* ((kind (funcall kindfunc cand))
-                  (icon-entry (cdr (assq (or kind t) nerd-icons-corfu-mapping)))
+      (when-let* ((kind (or (funcall kindfunc cand) t))
+                  (icon-entry (cdr (assq kind nerd-icons-corfu-mapping)))
                   (style (plist-get icon-entry :style))
                   (icon (plist-get icon-entry :icon))
                   (icon-fun (intern (concat "nerd-icons-" style "icon")))


### PR DESCRIPTION
When `completion-extra-properties` has no `:company-kind` property, the margin formatter returns `nil` instead of a string.

The problem occurs in particular when using `cape-company-to-capf` adapter and can be highlighted using the minimal `init.el` available at https://gist.github.com/fredericgiquel/8465527872cf1ae5b6bf8787b458292d
- open a shell file
- trigger a completion

It should lead to the following error: `Error in post-command-hook (corfu--post-command): (wrong-type-argument arrayp nil)`

This PR fixes the error.